### PR TITLE
Update minimum go version for building lotus

### DIFF
--- a/content/en/lotus/install/linux.md
+++ b/content/en/lotus/install/linux.md
@@ -126,10 +126,10 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 ### Go
 
-To build Lotus, you need a working installation of [Go 1.19.7 or higher](https://golang.org/dl/):
+To build Lotus, you need a working installation of [Go 1.19.12 or higher](https://golang.org/dl/):
 
 ```shell
-wget -c https://golang.org/dl/go1.19.7.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+wget -c https://golang.org/dl/go1.19.12.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
 ```
 
 {{< alert icon="tip">}}


### PR DESCRIPTION
Building requires go 1.19.12 as of lotus v1.23.3